### PR TITLE
eq/chore update setup and PR guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@ Make frequent commmits for what would be considered atomic units of work.
 
 Before you return control to the user, if you have new commits, push. If no PR exists yet, make one. Make the PR description using the /prepare-pr skill
 
+Opened PRs should use an `eq/` prefix followed by `feat`, `bug`, or `chore` depending on the PR's purpose. Use `feat` for features, `bug` for fixes, and `chore` for scripts, maintenance, or other changes that do not add real product functionality.
+
 When the user asks you to revise something you already did, or gives guidance that sounds like a reusable principle, ask whether they would like that feedback persisted into an `AGENTS.md` file for future agents.
 
 Scope `AGENTS.md` files to the directory where the guidance applies. Generic agent behavior and cross-repo preferences belong in this root `AGENTS.md`, which is symlinked into the global agent locations. Repo-specific instructions should live in that repo's `AGENTS.md`, and directory- or subsystem-specific instructions should live in the deepest relevant directory so only the right files inherit them. If a repo-specific rule reveals a broader reusable principle, that generalized principle may be added to this root `AGENTS.md` while the concrete repo-specific rule stays in the relevant repo or directory. Do not duplicate narrow instructions in broader files unless the broader file needs to point agents to where the narrower guidance lives.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,5 @@
 Make frequent commmits for what would be considered atomic units of work.
 
-When GitHub CLI is needed but unavailable, install it with `brew install gh`.
-
 Before you return control to the user, if you have new commits, push. If no PR exists yet, make one. Make the PR description using the /prepare-pr skill
 
 When the user asks you to revise something you already did, or gives guidance that sounds like a reusable principle, ask whether they would like that feedback persisted into an `AGENTS.md` file for future agents.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 Make frequent commmits for what would be considered atomic units of work.
 
+When GitHub CLI is needed but unavailable, install it with `brew install gh`.
+
 Before you return control to the user, if you have new commits, push. If no PR exists yet, make one. Make the PR description using the /prepare-pr skill
 
 When the user asks you to revise something you already did, or gives guidance that sounds like a reusable principle, ask whether they would like that feedback persisted into an `AGENTS.md` file for future agents.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 Make frequent commmits for what would be considered atomic units of work.
 
-Before you return control to the user, if you have new commits, push. If no PR exists yet, make one. Make the PR description using the /prepare-pr skill
+Before you return control to the user, if you have new commits, push. If no PR exists yet, make one. Make the PR description using the /prepare-pr skill. Keep the PR title and description updated so they accurately reflect the current status and scope of the PR as it evolves.
 
 Opened PRs should use an `eq/` prefix followed by `feat`, `bug`, or `chore` depending on the PR's purpose. Use `feat` for features, `bug` for fixes, and `chore` for scripts, maintenance, or other changes that do not add real product functionality.
 

--- a/mac_installs.sh
+++ b/mac_installs.sh
@@ -86,6 +86,14 @@ else
     echo "bat is already installed."
 fi
 
+# GitHub CLI
+if ! command -v gh &> /dev/null; then
+    echo "Installing GitHub CLI..."
+    brew install gh
+else
+    echo "GitHub CLI is already installed."
+fi
+
 # zsh highlighting
 if [ ! -d ~/zsh-syntax-highlighting ]; then
     echo "Installing zsh-syntax-highlighting..."


### PR DESCRIPTION
## Summary
- Install GitHub CLI from mac_installs.sh when gh is unavailable.
- Document the eq/[feat,bug,chore] convention for opened PRs.
- Document that PR titles and descriptions should evolve with PR status and scope.

## Verification
- Ran zsh -n mac_installs.sh.
- Reviewed the AGENTS.md diff.