### PR TITLE
eq/chore: update installation and agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@ Make frequent commmits for what would be considered atomic units of work.
 
 Before you return control to the user, if you have new commits, push. If no PR exists yet, make one. Make the PR description using the /prepare-pr skill. Keep the PR title and description updated so they accurately reflect the current status and scope of the PR as it evolves.
 
-Opened PRs should use an `eq/` prefix followed by `feat`, `bug`, or `chore` depending on the PR's purpose. Use `feat` for features, `bug` for fixes, and `chore` for scripts, maintenance, or other changes that do not add real product functionality.
+Opened PR branches should use the format `eq/<type>/<description>`, such as `eq/chore/update-install-scripts`, where `<type>` is `feat`, `bug`, or `chore` depending on the PR's purpose. Use `feat` for features, `bug` for fixes, and `chore` for scripts, maintenance, or other changes that do not add real product functionality.
 
 When the user asks you to revise something you already did, or gives guidance that sounds like a reusable principle, ask whether they would like that feedback persisted into an `AGENTS.md` file for future agents.
 

--- a/debian_installs.sh
+++ b/debian_installs.sh
@@ -30,6 +30,18 @@ fi
 # Create .local/bin directory
 mkdir -p ~/.local/bin
 
+# Rust/cargo
+if ! command -v cargo &> /dev/null && [ ! -x "$HOME/.cargo/bin/cargo" ]; then
+    echo "Installing cargo with rustup..."
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+else
+    echo "cargo is already installed."
+fi
+if [ -f "$HOME/.cargo/env" ]; then
+    grep -qxF '. "$HOME/.cargo/env"' ~/.zshrc || echo '. "$HOME/.cargo/env"' >> ~/.zshrc
+    . "$HOME/.cargo/env"
+fi
+
 # zsh
 if ! command -v zsh &> /dev/null; then
     echo "Installing zsh..."

--- a/mac_installs.sh
+++ b/mac_installs.sh
@@ -134,6 +134,18 @@ else
     echo "wget is already installed."
 fi
 
+# Rust/cargo
+if ! command -v cargo &> /dev/null && [ ! -x "$HOME/.cargo/bin/cargo" ]; then
+    echo "Installing cargo with rustup..."
+    curl https://sh.rustup.rs -sSf | sh -s -- -y
+else
+    echo "cargo is already installed."
+fi
+if [ -f "$HOME/.cargo/env" ]; then
+    grep -qxF '. "$HOME/.cargo/env"' ~/.zshrc || echo '. "$HOME/.cargo/env"' >> ~/.zshrc
+    . "$HOME/.cargo/env"
+fi
+
 # uv
 if ! command -v uv &> /dev/null; then
     echo "Installing uv..."

--- a/mac_installs.sh
+++ b/mac_installs.sh
@@ -30,7 +30,6 @@ if [[ $(uname -m) == "arm64" ]]; then
     fi
     grep -qxF 'export PATH="$PATH:/opt/nvim-macos-arm64/bin"' ~/.zshrc || echo 'export PATH="$PATH:/opt/nvim-macos-arm64/bin"' >> ~/.zshrc
 
-    brew install battery # This only works for apple silicon
 else
     echo "Detected Intel architecture"
 


### PR DESCRIPTION
## Summary
- Add rustup-based cargo installation to the macOS install script.
- Add the same cargo installation support to the Debian install script.
- Source `~/.cargo/env` when present so later install steps can use cargo in the same shell session.
- Disable the Apple Silicon `battery` Homebrew install.
- Clarify that opened PR branches should use `eq/<type>/<description>`, for example `eq/chore/update-install-scripts`.

## Validation
- `bash -n mac_installs.sh debian_installs.sh`