### PR TITLE
eq/chore: document lifecycle method ordering

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Function and method ordering:
 - Put each top-level function or method before the helpers that serve it.
 - Put those helpers immediately after that top-level function or method.
 - Then move on to the next top-level function or method and its helpers.
+- For a class that handles a business entity's lifecycle, order its methods by the sequence they are normally invoked in, such as create/setup methods first, then update/transition methods, then completion/archive/delete methods.
 - For example, if top-level function `A` uses helpers `a` and `b`, and top-level function `B` uses helpers `c` and `d`, prefer this order: `A`, `a`, `b`, `B`, `c`, `d`.
 
 Scope `AGENTS.md` files to the directory where the guidance applies. Generic agent behavior and cross-repo preferences belong in this root `AGENTS.md`, which is symlinked into the global agent locations. Repo-specific instructions should live in that repo's `AGENTS.md`, and directory- or subsystem-specific instructions should live in the deepest relevant directory so only the right files inherit them. If a repo-specific rule reveals a broader reusable principle, that generalized principle may be added to this root `AGENTS.md` while the concrete repo-specific rule stays in the relevant repo or directory. Do not duplicate narrow instructions in broader files unless the broader file needs to point agents to where the narrower guidance lives.


### PR DESCRIPTION
## Summary
- Add guidance for lifecycle-oriented business entity classes
- Clarify that lifecycle methods should follow normal invocation order, such as create/setup before update/transition and completion/archive/delete

## Tests
- Not run; documentation-only change